### PR TITLE
Reduce WMI query frequency to lower CPU usage

### DIFF
--- a/TabbedTortoiseGit/ProgramForm.cs
+++ b/TabbedTortoiseGit/ProgramForm.cs
@@ -77,7 +77,7 @@ namespace TabbedTortoiseGit
         {
             _startup = startup;
 
-            _watcher = new ManagementEventWatcher( new WqlEventQuery( "__InstanceCreationEvent", new TimeSpan( 10 ), TORTOISE_GIT_EVENT_QUERY ) );
+            _watcher = new ManagementEventWatcher( new WqlEventQuery( "__InstanceCreationEvent", TimeSpan.FromSeconds( 1 ), TORTOISE_GIT_EVENT_QUERY ) );
             _watcher.Options.Timeout = new TimeSpan( 0, 1, 0 );
             _watcher.EventArrived += Watcher_EventArrived;
             _watcher.Start();


### PR DESCRIPTION
The current WMI query frequency is set to 10 ticks (not milliseconds), which is equal to 1 microsecond. This causes nonstop querying from what I can tell, leading to abnormally high WMI host provider CPU usage. It pretty much maxes out a core on my machine. I reduced the frequency down to once a second to match the existing WatcherTimer frequency and that dropped the CPU usage down to around the 1-1.5% range on my machine. There may be some overlap now if both WMI queries run once a second, but I'm not really familiar enough with WMI to tell one way or the other.

There is a slightly more noticeable delay when opening new TortoiseGit processes before it gets recognized, but I think a 1s delay is pretty negligible overall vs the expensive WMI querying.